### PR TITLE
Formatting cleanup & CI dependency bumps

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -12,7 +12,7 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/add-julia-registry@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -31,7 +31,7 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/add-julia-registry@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
       - name: Delete preview and history + push changes

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -15,7 +15,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/add-julia-registry@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -30,7 +30,7 @@ jobs:
         run: julia --project=docs/ docs/make.jl
       - name: Make comment with preview link
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/Registry.yml
+++ b/.github/workflows/Registry.yml
@@ -14,7 +14,7 @@ jobs:
       actions: write
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/add-julia-registry@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibYAML2"
 uuid = "ea63f084-1c5d-45c5-8232-09ccaa2e0026"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/yaml_errors.jl
+++ b/src/yaml_errors.jl
@@ -106,14 +106,14 @@ function Base.showerror(io::IO, e::AbstractYAMLError)
     print(io, nameof(typeof(e)), ": ")
     if hasproperty(e, :context) && !isempty(e.context)
         print(io,
-          "in ", e.context,
-          " at line ", e.context_mark.line,
-          ", column ", e.context_mark.column, ": ")
+            "in ", e.context,
+            " at line ", e.context_mark.line,
+            ", column ", e.context_mark.column, ": ")
     end
     print(io,
-      e.problem,
-      " at line ", e.problem_mark.line,
-      ", column ", e.problem_mark.column)
+        e.problem,
+        " at line ", e.problem_mark.line,
+        ", column ", e.problem_mark.column)
 end
 
 function throw_yaml_err(parser::LibYAMLParser)


### PR DESCRIPTION
## Summary
- Bump patch version 0.1.0 → 0.1.1
- Fix paren-alignment → 4-space indent in `Base.showerror`
- Bump actions/checkout from 5 to 6
- Bump actions/github-script from 7 to 8

Closes #6, closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)