### PR TITLE
Add Green registry instruction to README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ A Julia wrapper for [libyaml](https://github.com/yaml/libyaml), providing fast a
 
 ## Installation
 
+If you haven't installed our [local registry](https://github.com/bhftbootcamp/Green) yet, do that first:
+
+```
+] registry add https://github.com/bhftbootcamp/Green.git
+```
+
 To install LibYAML2, simply use the Julia package manager:
 
 ```julia


### PR DESCRIPTION
## Summary
- Added the Green registry `] registry add` instruction to the installation section of `README.md`
- This matches the convention used in other bhftbootcamp Green-registry packages (e.g., CcyConv.jl, Librdkafka.jl)

## Details
LibYAML2.jl is published to the Green private registry, but the README's installation section was missing the prerequisite step of adding the registry. Users who don't already have the Green registry configured would not be able to install the package by just following the README instructions.